### PR TITLE
💄 Fix: Button inline padding

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -84,10 +84,10 @@ const Home: NextPage = () => {
           <span className="flex flex-col gap-2 mt-6 justify-center items-center scale-100 xs:scale-90 sm:scale-90 md:scale-95 lg:scale-100 xl:scale-100">
             <Link
               href="/home"
-              className="relative inline-flex items-center justify-start px-3 py-4 overflow-hidden font-bold rounded-full group"
+              className="relative inline-flex items-center justify-start px-8 py-4 overflow-hidden font-bold rounded-full group"
             >
               <span className="w-full h-full rotate-45 translate-x-12 -translate-y-2 absolute left-0 top-0 bg-white opacity-[3%]"></span>
-              <span className="absolute top-0 left-0 w-48 h-48 -mt-1 transition-all duration-500 ease-in-out rotate-45 -translate-x-56 -translate-y-24 bg-white opacity-100 group-hover:-translate-x-8"></span>
+              <span className="absolute w-[125%] left-[-125%] group-hover:left-[0] transition-all duration-500 inset-y-0 aspect-square bg-white [clip-path:polygon(0_0,_100%_0%,_0_100%,_0%_100%);]"></span>
               <span className="relative w-full text-2xl text-left text-white transition-colors duration-200 ease-in-out group-hover:text-gray-900">
                 Get Started
               </span>


### PR DESCRIPTION
Fix the inline size of the button to align the ends of the padding to the text.

The background item also had to be fixed, as it was previously a diagonal square with magic number transforms. This fix changes that to a clipped square with percentage transforms.