### PR TITLE
feat: support for inf-scroll-based browsing (movies)

### DIFF
--- a/pages/movies/[category]/index.tsx
+++ b/pages/movies/[category]/index.tsx
@@ -1,0 +1,242 @@
+import Card from "@components/Card";
+import PageTransition from "@components/Transition";
+import { Movie, TmdbResponse } from "@utils/typings";
+import axios from "axios";
+import { ChevronLeft } from "lucide-react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
+
+interface Props {
+  initialMovies: TmdbResponse;
+  category: string;
+}
+
+const GENRE_IDS = {
+  action: 28,
+  adventure: 12,
+  animation: 16,
+  comedy: 35,
+  crime: 80,
+  documentary: 99,
+  drama: 18,
+  family: 10751,
+  fantasy: 14,
+  history: 36,
+  horror: 27,
+  music: 10402,
+  mystery: 9648,
+  romance: 10749,
+  scifi: 878,
+  thriller: 53,
+  war: 10752,
+  western: 37,
+};
+
+const categoryTitles: { [key: string]: string } = {
+  popular: "Popular Movies",
+  top_rated: "Top Rated Movies",
+  upcoming: "Upcoming Movies",
+  now_playing: "Now Playing Movies",
+  horror: "Horror Movies",
+  thriller: "Thriller Movies",
+  action: "Action Movies",
+  comedy: "Comedy Movies",
+  romance: "Romance Movies",
+  documentary: "Documentary Movies",
+  drama: "Drama Movies",
+  fantasy: "Fantasy Movies",
+  scifi: "Sci-Fi Movies",
+  adventure: "Adventure Movies",
+  animation: "Animated Movies",
+  crime: "Crime Movies",
+  music: "Music Movies",
+  mystery: "Mystery Movies",
+  war: "War Movies",
+  western: "Western Movies",
+  history: "History Movies",
+  family: "Family Movies",
+};
+
+const TMDB_BASE_URL = "https://api.themoviedb.org/3";
+const API_KEY = process.env.NEXT_PUBLIC_TMDB_API_KEY;
+
+export const filterMovies = (movies: Movie[]): Movie[] => {
+  if (!Array.isArray(movies)) return [];
+  return movies.filter((movie) => {
+    if (!movie || typeof movie !== "object") return false;
+    if (!movie.poster_path) return false;
+    if (movie.adult) return false;
+    if (movie.original_language !== "en") return false;
+    return true;
+  });
+};
+
+const isGenreCategory = (category: string): boolean => {
+  return category in GENRE_IDS;
+};
+
+const getApiUrl = (category: string, page: number): string => {
+  if (isGenreCategory(category)) {
+    return `${TMDB_BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&page=${page}&with_genres=${
+      GENRE_IDS[category as keyof typeof GENRE_IDS]
+    }&region=US&include_adult=false&certification_country=US&certification.lte=PG-13`;
+  }
+  return `${TMDB_BASE_URL}/movie/${category}?api_key=${API_KEY}&language=en-US&page=${page}&region=US&include_adult=false&certification_country=US&certification.lte=PG-13`;
+};
+
+export default function CategoryPage({ initialMovies, category }: Props) {
+  const router = useRouter();
+  const [movies, setMovies] = useState<Movie[]>(
+    initialMovies.results as Movie[],
+  );
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const { ref, inView } = useInView();
+
+  const fetchMoreMovies = async () => {
+    if (loading || !hasMore) return;
+
+    try {
+      setLoading(true);
+      const nextPage = page + 1;
+      const response = await axios.get(getApiUrl(category, nextPage));
+      const newMovies = filterMovies(response.data.results);
+
+      if (newMovies.length === 0) {
+        setHasMore(false);
+        return;
+      }
+
+      setMovies((prev) => [...prev, ...newMovies]);
+      setPage(nextPage);
+    } catch (error) {
+      console.error("Error fetching movies:", error);
+      setHasMore(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (inView) {
+      fetchMoreMovies();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inView]);
+
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
+
+  if (!movies.length) {
+    return <div>No movies found</div>;
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{categoryTitles[category] || "Movies"} | NyumatFlix</title>
+        <meta
+          name="description"
+          content={`View ${categoryTitles[category] || "movies"} on NyumatFlix.`}
+        />
+      </Head>
+      <PageTransition>
+        <div className="container mx-auto px-4">
+          <div className="flex items-center justify-between mb-6">
+            <h1 className="text-4xl font-bold text-white">
+              {categoryTitles[category] || "Movies"}
+            </h1>
+            <Link
+              href="/movies"
+              className="flex items-center gap-2 text-white hover:text-gray-300 transition-colors"
+            >
+              <ChevronLeft className="w-5 h-5" />
+              Back to Movies
+            </Link>
+          </div>
+
+          <div className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+            {movies.map((movie: Movie) => (
+              <Card key={`${movie.id}-${movie.title}`} item={movie} />
+            ))}
+          </div>
+
+          {hasMore && (
+            <div
+              ref={ref}
+              className="w-full h-20 flex items-center justify-center"
+            >
+              {loading && <div>Loading more movies...</div>}
+            </div>
+          )}
+        </div>
+      </PageTransition>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  const categories = [
+    "popular",
+    "top_rated",
+    "upcoming",
+    "now_playing",
+    "horror",
+    "thriller",
+    "action",
+    "comedy",
+    "romance",
+    "documentary",
+    "drama",
+    "fantasy",
+    "scifi",
+    "adventure",
+    "animation",
+    "crime",
+    "music",
+    "mystery",
+    "war",
+    "western",
+    "history",
+    "family",
+  ];
+
+  const paths = categories.map((category) => ({
+    params: { category },
+  }));
+
+  return {
+    paths,
+    fallback: true,
+  };
+}
+
+export async function getStaticProps({
+  params,
+}: {
+  params: { category: string };
+}) {
+  try {
+    const response = await axios.get(getApiUrl(params.category, 1));
+
+    return {
+      props: {
+        initialMovies: {
+          results: response.data.results,
+        },
+        category: params.category,
+      },
+      revalidate: 60 * 60,
+    };
+  } catch (error) {
+    console.error("Error fetching movies:", error);
+    return {
+      notFound: true,
+    };
+  }
+}

--- a/pages/movies/index.tsx
+++ b/pages/movies/index.tsx
@@ -1,12 +1,13 @@
-import Card from "@components/Card";
+import React, { useEffect, useRef, useState } from "react";
+import Head from "next/head";
 import PageTransition from "@components/Transition";
+import Card from "@components/Card";
 import { MOVIE_CATEGORIES } from "@utils/requests";
 import { Movie } from "@utils/typings";
-import axios from "axios";
 import { ChevronRight } from "lucide-react";
-import Head from "next/head";
 import Link from "next/link";
 import { filterMovies } from "./[category]";
+import axios from "axios";
 
 interface MovieCategory {
   title: string;
@@ -15,51 +16,9 @@ interface MovieCategory {
 }
 
 interface Props {
-  categories: MovieCategory[];
+  initialCategories: MovieCategory[];
+  categoryKeys: string[];
 }
-
-const Page = ({ categories }: Props) => {
-  return (
-    <>
-      <Head>
-        <title>Movies | NyumatFlix</title>
-        <meta
-          name="description"
-          content="View the latest movies on NyumatFlix."
-        />
-      </Head>
-      <PageTransition>
-        <div>
-          {categories.map((category) => (
-            <div key={category.query} className="mb-8">
-              <div className="flex items-center justify-between mb-4 px-4">
-                <h1 className="text-xl md:text-2xl lg:text-4xl font-bold text-white">
-                  {category.title}
-                </h1>
-                <Link
-                  href={`/movies/${category.query}`}
-                  className="flex items-center gap-2 text-white hover:text-gray-300 transition-colors"
-                >
-                  View All
-                  <ChevronRight className="w-5 h-5" />
-                </Link>
-              </div>
-              <div className="relative">
-                <div className="flex overflow-x-scroll scrollbar-hide space-x-4 px-4">
-                  {category.movies.map((movie: Movie) => (
-                    <div key={movie.id} className="flex-none w-[200px]">
-                      <Card item={movie} />
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </PageTransition>
-    </>
-  );
-};
 
 async function fetchMoviesUntilCount(
   categoryKey: string,
@@ -82,9 +41,150 @@ async function fetchMoviesUntilCount(
   return allMovies.slice(0, targetCount);
 }
 
+const CategoryRow = ({ category }: { category: MovieCategory }) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setIsLoaded(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} className="mb-8">
+      <div className="flex items-center justify-between mb-4 px-4">
+        <h1 className="text-xl md:text-2xl lg:text-4xl font-bold text-white">
+          {category.title}
+        </h1>
+        <Link
+          href={`/movies/${category.query}`}
+          className="flex items-center gap-2 text-white hover:text-gray-300 transition-colors"
+        >
+          View All
+          <ChevronRight className="w-5 h-5" />
+        </Link>
+      </div>
+      <div className="relative">
+        <div className="flex overflow-x-scroll scrollbar-hide space-x-4 px-4">
+          {isLoaded
+            ? category.movies.map((movie: Movie) => (
+                <div key={movie.id} className="flex-none w-[200px]">
+                  <Card item={movie} />
+                </div>
+              ))
+            : [...Array(5)].map((_, i) => (
+                <div key={i} className="flex-none w-[200px] animate-pulse">
+                  <div className="w-full aspect-[2/3] bg-gray-700 rounded-lg mb-2" />
+                  <div className="h-4 bg-gray-700 rounded w-3/4 mb-2" />
+                  <div className="h-4 bg-gray-700 rounded w-1/2" />
+                </div>
+              ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const Page = ({ initialCategories, categoryKeys }: Props) => {
+  const [loadedCategories, setLoadedCategories] =
+    useState<MovieCategory[]>(initialCategories);
+  const [isLoading, setIsLoading] = useState(false);
+  const loaderRef = useRef<HTMLDivElement>(null);
+  const remainingKeysRef = useRef(categoryKeys.slice(5));
+
+  const fetchNextCategories = async () => {
+    const nextKeys = remainingKeysRef.current.slice(0, 5);
+    if (nextKeys.length === 0) return;
+
+    const categories = await Promise.all(
+      nextKeys.map(async (categoryKey) => {
+        const category =
+          MOVIE_CATEGORIES[categoryKey as keyof typeof MOVIE_CATEGORIES];
+        const movies = await fetchMoviesUntilCount(categoryKey, category, 10);
+        return {
+          query: categoryKey,
+          title: category.title,
+          movies,
+        };
+      }),
+    );
+
+    remainingKeysRef.current = remainingKeysRef.current.slice(5);
+    return categories;
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      async (entries) => {
+        if (
+          entries[0].isIntersecting &&
+          !isLoading &&
+          remainingKeysRef.current.length > 0
+        ) {
+          setIsLoading(true);
+          const newCategories = await fetchNextCategories();
+          if (newCategories) {
+            setLoadedCategories((prev) => [...prev, ...newCategories]);
+          }
+          setIsLoading(false);
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    if (loaderRef.current) {
+      observer.observe(loaderRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [isLoading]);
+
+  return (
+    <>
+      <Head>
+        <title>Movies | NyumatFlix</title>
+        <meta
+          name="description"
+          content="View the latest movies on NyumatFlix."
+        />
+      </Head>
+      <PageTransition>
+        <div>
+          {loadedCategories.map((category) => (
+            <CategoryRow key={category.query} category={category} />
+          ))}
+          {remainingKeysRef.current.length > 0 && (
+            <div
+              ref={loaderRef}
+              className="h-20 flex items-center justify-center"
+            >
+              {isLoading && (
+                <div className="w-8 h-8 border-4 border-t-white border-white/20 rounded-full animate-spin" />
+              )}
+            </div>
+          )}
+        </div>
+      </PageTransition>
+    </>
+  );
+};
+
 export async function getStaticProps() {
   try {
-    const categoriesToShow = [
+    const allCategories = [
       "popular",
       "top_rated",
       "now_playing",
@@ -109,30 +209,32 @@ export async function getStaticProps() {
       "western",
     ];
 
-    const categoryPromises = categoriesToShow.map(async (categoryKey) => {
-      const category =
-        MOVIE_CATEGORIES[categoryKey as keyof typeof MOVIE_CATEGORIES];
-      const movies = await fetchMoviesUntilCount(categoryKey, category);
-      return {
-        query: categoryKey,
-        title: category.title,
-        movies,
-      };
-    });
-
-    const categories = await Promise.all(categoryPromises);
+    const initialCategories = await Promise.all(
+      allCategories.slice(0, 5).map(async (categoryKey) => {
+        const category =
+          MOVIE_CATEGORIES[categoryKey as keyof typeof MOVIE_CATEGORIES];
+        const movies = await fetchMoviesUntilCount(categoryKey, category, 10);
+        return {
+          query: categoryKey,
+          title: category.title,
+          movies,
+        };
+      }),
+    );
 
     return {
       props: {
-        categories,
+        initialCategories,
+        categoryKeys: allCategories,
       },
-      revalidate: 60 * 60,
+      revalidate: 60 * 60, // Revalidate every hour
     };
   } catch (error) {
     console.error("Error fetching movies:", error);
     return {
       props: {
-        categories: [],
+        initialCategories: [],
+        categoryKeys: [],
       },
       revalidate: 60,
     };

--- a/pages/movies/watch/[id]/index.tsx
+++ b/pages/movies/watch/[id]/index.tsx
@@ -19,12 +19,9 @@ interface PlayerProps {
 
 const WatchMovie = ({ movie, actors, url }: PlayerProps) => {
   const router = useRouter();
-
   const { id } = router.query;
   const ts_id = parseInt(id as string);
 
-  // const { isAvailable } = useAvailable(ts_id);
-  //console.log(url);
   if (!url) {
     return (
       <div>

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -3,25 +3,128 @@ const VPS = process.env.NYUMATFLIX_VPS;
 const VPS2 = process.env.NYUMATFLIX_VPS2;
 const BASE_URL = "https://api.themoviedb.org/3";
 
+const defaultQueryParams =
+  "language=en-US&include_adult=false&with_original_language=en";
+
+export const MOVIE_CATEGORIES = {
+  popular: {
+    title: "Popular Movies",
+    url: `${BASE_URL}/movie/popular?api_key=${API_KEY}&${defaultQueryParams}`,
+  },
+  top_rated: {
+    title: "Top Rated Movies",
+    url: `${BASE_URL}/movie/top_rated?api_key=${API_KEY}&${defaultQueryParams}`,
+  },
+  upcoming: {
+    title: "Upcoming Movies",
+    url: `${BASE_URL}/movie/upcoming?api_key=${API_KEY}&${defaultQueryParams}`,
+  },
+  now_playing: {
+    title: "Now Playing Movies",
+    url: `${BASE_URL}/movie/now_playing?api_key=${API_KEY}&${defaultQueryParams}`,
+  },
+  action: {
+    title: "Action Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=28`,
+    genreId: 28,
+  },
+  adventure: {
+    title: "Adventure Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=12`,
+    genreId: 12,
+  },
+  animation: {
+    title: "Animation Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=16`,
+    genreId: 16,
+  },
+  comedy: {
+    title: "Comedy Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=35`,
+    genreId: 35,
+  },
+  crime: {
+    title: "Crime Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=80`,
+    genreId: 80,
+  },
+  documentary: {
+    title: "Documentary Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=99`,
+    genreId: 99,
+  },
+  drama: {
+    title: "Drama Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=18`,
+    genreId: 18,
+  },
+  family: {
+    title: "Family Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=10751`,
+    genreId: 10751,
+  },
+  fantasy: {
+    title: "Fantasy Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=14`,
+    genreId: 14,
+  },
+  history: {
+    title: "History Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=36`,
+    genreId: 36,
+  },
+  horror: {
+    title: "Horror Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=27`,
+    genreId: 27,
+  },
+  music: {
+    title: "Music Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=10402`,
+    genreId: 10402,
+  },
+  mystery: {
+    title: "Mystery Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=9648`,
+    genreId: 9648,
+  },
+  romance: {
+    title: "Romance Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=10749`,
+    genreId: 10749,
+  },
+  science_fiction: {
+    title: "Science Fiction Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=878`,
+    genreId: 878,
+  },
+  thriller: {
+    title: "Thriller Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=53`,
+    genreId: 53,
+  },
+  war: {
+    title: "War Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=10752`,
+    genreId: 10752,
+  },
+  western: {
+    title: "Western Movies",
+    url: `${BASE_URL}/discover/movie?api_key=${API_KEY}&${defaultQueryParams}&with_genres=37`,
+    genreId: 37,
+  },
+};
+
 const requests = {
   fetchMoviePlayer: `${VPS}`,
   fetchTelevisionPlayer: `${VPS2}`,
-  fetchTrendingMovies: `${BASE_URL}/trending/movie/week?api_key=${API_KEY}&language=en-US`,
-  fetchTrendingTvShows: `${BASE_URL}/trending/tv/week?api_key=${API_KEY}&language=en-US`,
-  fetchTopRatedMovies: `${BASE_URL}/movie/top_rated?api_key=${API_KEY}&language=en-US`,
-  fetchPopularMovies: `${BASE_URL}/movie/popular?api_key=${API_KEY}&language=en-US`,
-  fetchUpcomingMovies: `${BASE_URL}/movie/upcoming?api_key=${API_KEY}&language=en-US`,
-  fetchNowPlayingMovies: `${BASE_URL}/movie/now_playing?api_key=${API_KEY}&language=en-US`,
-  fetchActionMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=28`,
-  fetchComedyMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=35`,
-  fetchHorrorMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=27`,
-  fetchRomanceMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=10749`,
-  fetchDocumentaries: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=99`,
-  fetchTopTvShows: `${BASE_URL}/tv/top_rated?api_key=${API_KEY}&language=en-US`,
-  fetchPopularTvShows: `${BASE_URL}/tv/popular?api_key=${API_KEY}&language=en-US`,
-  fetchAiringTodayTvShows: `${BASE_URL}/tv/airing_today?api_key=${API_KEY}&language=en-US`,
-  fetchTopRatedTvShows: `${BASE_URL}/tv/top_rated?api_key=${API_KEY}&language=en-US`,
-  fetchOnTheAirTvShows: `${BASE_URL}/tv/on_the_air?api_key=${API_KEY}&language=en-US`,
+  fetchTrendingMovies: `${BASE_URL}/trending/movie/week?api_key=${API_KEY}&${defaultQueryParams}`,
+  fetchTrendingTvShows: `${BASE_URL}/trending/tv/week?api_key=${API_KEY}&${defaultQueryParams}`,
+  fetchTopTvShows: `${BASE_URL}/tv/top_rated?api_key=${API_KEY}&${defaultQueryParams}`,
+  fetchPopularTvShows: `${BASE_URL}/tv/popular?api_key=${API_KEY}&${defaultQueryParams}`,
+  fetchAiringTodayTvShows: `${BASE_URL}/tv/airing_today?api_key=${API_KEY}&${defaultQueryParams}`,
+  fetchTopRatedTvShows: `${BASE_URL}/tv/top_rated?api_key=${API_KEY}&${defaultQueryParams}`,
+  fetchOnTheAirTvShows: `${BASE_URL}/tv/on_the_air?api_key=${API_KEY}&${defaultQueryParams}`,
 };
 
 export default requests;

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -1,7 +1,7 @@
-const API_KEY = process.env.API_KEY;
+export const API_KEY = process.env.NEXT_PUBLIC_TMDB_API_KEY;
 const VPS = process.env.NYUMATFLIX_VPS;
 const VPS2 = process.env.NYUMATFLIX_VPS2;
-const BASE_URL = "https://api.themoviedb.org/3";
+export const BASE_URL = "https://api.themoviedb.org/3";
 
 const defaultQueryParams =
   "language=en-US&include_adult=false&with_original_language=en";


### PR DESCRIPTION
This PR introduces infinite scroll-based pagination to NyumatFlix, significantly enhancing the browsing experience for users. 

Previously, there was no convenient way to explore large selections of movies without knowing a specific title in advance. Now, users can continuously scroll through movie categories without pagination limits.

## What's New
- I Implemented infinite scrolling for all movie categories.
- Movies are dynamically loaded as users scroll, allowing for seamless exploration of larger movie selections.
- This feature is supported for **all movie categories** like Popular, Top Rated, Upcoming, Horror, and more.
- Updated the user interface to accommodate continuous movie loading.

## Changes
- Added scroll-based movie fetching on the category pages.
- Configured API endpoints for multiple movie categories.
- Introduced dynamic loading logic that fetches additional movies when the user reaches the bottom of the page.

> [!NOTE]  
> Feature parity for this with Tv Shows is coming soon, I just wanted to get this out for now.

## Preview

https://github.com/user-attachments/assets/ac13c024-8450-4b26-b4c5-922330ec60a8

