### PR TITLE
ui/ux: address some feedback from a kind soul

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -16,11 +16,11 @@ import {
   IconMovie,
   IconPlayerPlay,
 } from "@tabler/icons";
+import { cn } from "@utils/styling";
 import { MapGenreMovie, MediaItem, Movie, TvShow } from "@utils/typings";
 import moment from "moment";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import { useState } from "react";
 
 interface CardProps {
   item: MediaItem | Movie | TvShow;
@@ -31,7 +31,6 @@ export default function Component({ item, mediaType }: CardProps) {
   const router = useRouter();
   const [previewOpened, { open: openPreview, close: closePreview }] =
     useDisclosure(false);
-  const [isLongPressed, setIsLongPressed] = useState(false);
   const isMobile = useMediaQuery("(max-width: 768px)");
 
   const handleWatch = () => {
@@ -46,21 +45,6 @@ export default function Component({ item, mediaType }: CardProps) {
     }
   };
 
-  const handleTouchStart = () => {
-    const timer = setTimeout(() => {
-      setIsLongPressed(true);
-      openPreview();
-    }, 1000);
-    return () => clearTimeout(timer);
-  };
-
-  const handleTouchEnd = () => {
-    if (!isLongPressed && !previewOpened) {
-      handleWatch();
-    }
-    setIsLongPressed(false);
-  };
-
   if (!item) return null;
 
   return (
@@ -68,14 +52,16 @@ export default function Component({ item, mediaType }: CardProps) {
       <MantineCard
         p={0}
         radius="md"
-        className="w-full transition-transform duration-300 cursor-pointer bg-transparent border-0 hover:scale-105 hover:z-10"
+        className={cn(
+          "w-full transition-transform duration-300 bg-transparent border-0",
+          {
+            "hover:scale-105 hover:z-10": !isMobile,
+          },
+        )}
         tabIndex={0}
-        role="button"
         aria-label={item.title}
         onKeyDown={handleKeyDown}
-        onClick={isMobile ? undefined : undefined}
-        onTouchStart={isMobile ? handleTouchStart : undefined}
-        onTouchEnd={isMobile ? handleTouchEnd : undefined}
+        onClick={isMobile ? openPreview : undefined}
       >
         <div className="relative aspect-[2/3] w-full">
           <Image

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "@tiptap/starter-kit": "^2.0.0-beta.209",
     "@vercel/analytics": "^1.3.1",
     "axios": "^1.2.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "country-flag-icons": "^1.5.13",
     "dayjs": "^1.11.7",
     "embla-carousel-react": "^7.0.5",
@@ -55,6 +57,7 @@
     "sharp": "^0.33.5",
     "swr": "^2.0.0",
     "tailwind-merge": "^2.5.4",
+    "tailwindcss-animate": "^1.0.7",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/pages/movies/[category]/index.tsx
+++ b/pages/movies/[category]/index.tsx
@@ -155,7 +155,7 @@ export default function CategoryPage({ initialMovies, category }: Props) {
 
     return (
       <PageTransition>
-        <div className="container mx-auto px-4">
+        <div className="mx-auto px-4">
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-4xl font-bold text-white">
               {categoryTitles[category] || "Movies"}
@@ -169,7 +169,7 @@ export default function CategoryPage({ initialMovies, category }: Props) {
             </Link>
           </div>
 
-          <div className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
             {movies.map((movie: Movie) => (
               <Card
                 key={`${movie.id}-${movie.title}`}

--- a/pages/movies/watch/[id]/index.tsx
+++ b/pages/movies/watch/[id]/index.tsx
@@ -69,11 +69,11 @@ const WatchMovie = ({ movie, actors, url }: PlayerProps) => {
             shadow="lg"
             radius="md"
             p="md"
-            withBorder
+            withBorder={false}
             className="h-full py-4"
           >
             <Stack spacing="xs" align="center">
-              <Box className="relative w-32 h-32 rounded-full overflow-hidden py-12">
+              <Box className="relative w-40 h-40 rounded-full overflow-hidden py-6">
                 <Image
                   src={`https://image.tmdb.org/t/p/w185${actor.profile_path}`}
                   alt={actor.name}
@@ -81,10 +81,20 @@ const WatchMovie = ({ movie, actors, url }: PlayerProps) => {
                   className="object-cover"
                 />
               </Box>
-              <Text size="sm" weight={600} align="center">
+              <Text
+                size="sm"
+                weight={600}
+                align="center"
+                className="text-white"
+              >
                 {actor.name}
               </Text>
-              <Text size="xs" color="dimmed" align="center">
+              <Text
+                size="xs"
+                color="dimmed"
+                align="center"
+                className="text-gray-400"
+              >
                 {actor.character}
               </Text>
             </Stack>
@@ -128,7 +138,7 @@ const WatchMovie = ({ movie, actors, url }: PlayerProps) => {
       />
 
       {/* black div overlays */}
-      <div className="absolute inset-0 z-0 bg-black/70 rounded-md -m-2"></div>
+      <div className="absolute inset-0 z-0 bg-black/60 rounded-md -m-2"></div>
 
       <Container size="xl" className="relative h-full z-10">
         <Group position="apart" className="h-full">

--- a/pages/tvshows/[category]/index.tsx
+++ b/pages/tvshows/[category]/index.tsx
@@ -161,7 +161,7 @@ export default function CategoryPage({ initialTvShows, category }: Props) {
         />
       </Head>
       <PageTransition>
-        <div className="container mx-auto px-4">
+        <div className="mx-auto px-4">
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-4xl font-bold text-white">
               {categoryTitles[category] || "TV Shows"}
@@ -175,7 +175,7 @@ export default function CategoryPage({ initialTvShows, category }: Props) {
             </Link>
           </div>
 
-          <div className="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
             {shows.map((show) => (
               <Card
                 key={`${show.id}-${show.title}`}

--- a/utils/styling.ts
+++ b/utils/styling.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
Got some feedback on the styling of certain things with this new minor version, so I addressed them in this PR.

## What changed
- Fixed card hover behavior on mobile from being confusing. Preview is now the entry point on mobile
- Added `clsx` because I needed a `cn()` utility for merging classnames and styles
- Lowered the minimum grid cols on browsing page from 3 to 2 on mobile so the UI doesn't feel as cramped
- Removed the border from the cast list and made the images larger (thanks Tony!)

## What it look like

## Better mobile UI
![Screenshot 2024-10-31 at 6 44 05 PM](https://github.com/user-attachments/assets/1bab6c40-5a7e-444d-a79d-1acdc7414976)

## Better cast list UI (WIP, tbh)
![Screenshot 2024-10-31 at 6 44 36 PM](https://github.com/user-attachments/assets/39675c01-8502-4a9d-aa53-4c06ec92e5b7)
