### PR TITLE
Fixed consistent tooltips for Genre badges by passing media type as prop

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -171,6 +171,7 @@ function MediaInfoDialog({
 
   const isMovie = "title" in media;
   const mediaType = isMovie ? "Movie" : "TV Show";
+  const mediaInfoDialogType = isMovie ? "movie" : "tv";
 
   // Safely access enhanced properties
   const runtime =
@@ -300,6 +301,7 @@ function MediaInfoDialog({
                         genreId={genre.id}
                         className="text-xs bg-white/10 border-white/20 text-white"
                         genreName={genre.name}
+                        mediaType={mediaInfoDialogType}
                       />
                     ))}
                   </div>

--- a/components/hero/hero-content.tsx
+++ b/components/hero/hero-content.tsx
@@ -143,7 +143,7 @@ export function HeroContent({
                         {media.tagline}
                       </p>
                     )}
-                    <HeroGenres genres={media.genres} />
+                    <HeroGenres genres={media.genres} mediaType={mediaType} />
                   </>
                 )}
                 <HeroDetails

--- a/components/hero/hero-genres.tsx
+++ b/components/hero/hero-genres.tsx
@@ -7,7 +7,7 @@ interface HeroGenresProps {
   mediaType?: "movie" | "tv";
 }
 
-export function HeroGenres({ genres, mediaType = "movie" }: HeroGenresProps) {
+export function HeroGenres({ genres, mediaType }: HeroGenresProps) {
   if (!genres || genres.length === 0) {
     return null;
   }

--- a/components/ui/genre-badge.tsx
+++ b/components/ui/genre-badge.tsx
@@ -22,7 +22,7 @@ interface GenreBadgeProps {
 export function GenreBadge({
   genreId,
   genreName,
-  mediaType = "movie",
+  mediaType,
   variant = "secondary",
   className,
   clickable = true,


### PR DESCRIPTION
Updated Genre badges in Media Info Dialog and Hero components to correctly display the media type. Previously, TV Shows incorrectly showed "Movies" in their labels and tooltips. The components now utilize passed media types as props for accurate rendering.