### PR TITLE
📜 fix scroll restoration issue with next.js

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,6 +99,11 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: "history.scrollRestoration='manual'",
+          }}
+        />
         {process.env.NODE_ENV === "production" && (
           <>
             <Script

--- a/app/movies/[id]/loading.tsx
+++ b/app/movies/[id]/loading.tsx
@@ -1,5 +1,13 @@
+"use client";
+
+import { scrollToTop } from "@/components/layout/route-scroll-reset";
 import { DetailTabPanelsLoading } from "@/components/layout/page-loading/detail-page-loading";
+import { useLayoutEffect } from "react";
 
 export default function MovieDetailLoading() {
+  useLayoutEffect(() => {
+    scrollToTop();
+  }, []);
+
   return <DetailTabPanelsLoading />;
 }

--- a/app/tvshows/[id]/loading.tsx
+++ b/app/tvshows/[id]/loading.tsx
@@ -1,5 +1,13 @@
+"use client";
+
+import { scrollToTop } from "@/components/layout/route-scroll-reset";
 import { DetailTabPanelsLoading } from "@/components/layout/page-loading/detail-page-loading";
+import { useLayoutEffect } from "react";
 
 export default function TvShowDetailLoading() {
+  useLayoutEffect(() => {
+    scrollToTop();
+  }, []);
+
   return <DetailTabPanelsLoading />;
 }

--- a/components/layout/route-scroll-reset.tsx
+++ b/components/layout/route-scroll-reset.tsx
@@ -3,13 +3,26 @@
 import { usePathname } from "next/navigation";
 import { useEffect, useLayoutEffect, useState } from "react";
 
-const scrollToTop = () => {
+export const scrollToTop = () => {
   const html = document.documentElement;
   const previous = html.style.scrollBehavior;
 
   html.style.scrollBehavior = "auto";
   window.scrollTo({ top: 0, left: 0, behavior: "auto" });
   html.style.scrollBehavior = previous;
+};
+
+export const stabilizeScrollTop = (
+  delaysMs: number[] = [0, 50, 150, 400, 550, 700],
+) => {
+  scrollToTop();
+  for (const delay of delaysMs) {
+    if (delay === 0) {
+      requestAnimationFrame(scrollToTop);
+      continue;
+    }
+    window.setTimeout(scrollToTop, delay);
+  }
 };
 
 const isMediaDetailPath = (pathname: string) =>

--- a/components/media/media-detail-scroll-reset.tsx
+++ b/components/media/media-detail-scroll-reset.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { stabilizeScrollTop } from "@/components/layout/route-scroll-reset";
 import { useLayoutEffect } from "react";
 
 type MediaDetailScrollResetProps = {
@@ -10,11 +11,7 @@ export const MediaDetailScrollReset = ({
   restoreKey,
 }: MediaDetailScrollResetProps) => {
   useLayoutEffect(() => {
-    const html = document.documentElement;
-    const previous = html.style.scrollBehavior;
-    html.style.scrollBehavior = "auto";
-    window.scrollTo(0, 0);
-    html.style.scrollBehavior = previous;
+    stabilizeScrollTop([0, 50, 150, 400]);
   }, [restoreKey]);
 
   return null;

--- a/hooks/useMediaHero.ts
+++ b/hooks/useMediaHero.ts
@@ -11,8 +11,16 @@ import { useEpisodeStore } from "@/lib/stores/episode-store";
 import type { MediaItem } from "@/lib/domain/typings";
 import { getFirstRegularSeason, isTVShow } from "@/lib/domain/typings";
 import { LegacyAnimationControls, useAnimation } from "framer-motion";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { stabilizeScrollTop } from "@/components/layout/route-scroll-reset";
+import { usePathname, useSearchParams } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 const readImdbIdFromMediaItem = (
   item: MediaItem | undefined,
@@ -87,9 +95,13 @@ export const useMediaHero = ({
   const [historyLength, setHistoryLength] = useState<number>(2);
   const controls = useAnimation();
 
-  const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const autoplayHandledRef = useRef(false);
+
+  useEffect(() => {
+    autoplayHandledRef.current = false;
+  }, [pathname]);
 
   const handleNext = useCallback(() => {
     setCurrentItemIndex((prevIndex) =>
@@ -153,9 +165,14 @@ export const useMediaHero = ({
     setIsPlayingVideo(true);
   }, []);
 
+  useLayoutEffect(() => {
+    if (searchParams.get("autoplay") !== "true" || !isWatch) return;
+    stabilizeScrollTop();
+  }, [searchParams, isWatch]);
+
   useEffect(() => {
     const shouldAutoplay = searchParams.get("autoplay") === "true";
-    if (!shouldAutoplay || !isWatch) return;
+    if (!shouldAutoplay || !isWatch || autoplayHandledRef.current) return;
 
     let timer: ReturnType<typeof setTimeout> | null = null;
     const maybeAutoplay = async () => {
@@ -187,13 +204,14 @@ export const useMediaHero = ({
       }
 
       timer = setTimeout(() => {
+        autoplayHandledRef.current = true;
         handleWatch();
         const params = new URLSearchParams(searchParams.toString());
         params.delete("autoplay");
         const newSearch = params.toString();
-        router.replace(`${pathname}${newSearch ? `?${newSearch}` : ""}`, {
-          scroll: false,
-        });
+        const nextUrl = `${pathname}${newSearch ? `?${newSearch}` : ""}`;
+        window.history.replaceState(window.history.state, "", nextUrl);
+        stabilizeScrollTop();
       }, 500);
     };
 
@@ -204,7 +222,6 @@ export const useMediaHero = ({
   }, [
     searchParams,
     isWatch,
-    router,
     pathname,
     passedMediaType,
     currentItem,


### PR DESCRIPTION
next.js restored scrolls for the detail routes right when autoplay stripped the query param, causing restoration to break.

this is a known ([1](https://github.com/vercel/next.js/issues/74485), [2](https://github.com/vercel/next.js/issues/84423)) issue with next, and can't really afford to upgrade to 16 right now, so this _hacky_ solution will-do for now. 