### PR TITLE
Home personalization and watch history

### DIFF
--- a/__tests__/personalization-features.test.ts
+++ b/__tests__/personalization-features.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { EpisodeInfo } from "@/lib/domain/episodes";
+import type { WatchlistItem } from "@/lib/domain/watchlist";
+import {
+  buildUpNextHref,
+  collectUpNextCandidates,
+  isUpNextInboxCandidate,
+} from "@/lib/personalization/up-next";
+import {
+  collectWatchHistoryStubs,
+  WATCH_HISTORY_LIMIT,
+} from "@/lib/playback/recently-watched";
+
+const baseEpisodeInfo = (
+  overrides: Partial<EpisodeInfo> = {},
+): EpisodeInfo => ({
+  hasNewEpisodes: false,
+  newEpisodeCount: 0,
+  hasUnwatchedEpisodes: true,
+  unwatchedEpisodeCount: 1,
+  nextUnwatchedEpisode: { seasonNumber: 2, episodeNumber: 1 },
+  nextEpisodeDate: null,
+  countdown: null,
+  latestEpisodeAirDate: new Date("2026-08-01T00:00:00.000Z"),
+  ...overrides,
+});
+
+const watchingTvItem = (
+  contentId: number,
+  overrides: Partial<WatchlistItem> = {},
+): WatchlistItem => ({
+  id: `item-${contentId}`,
+  userId: "user-1",
+  contentId,
+  mediaType: "tv",
+  status: "watching",
+  lastWatchedSeason: 1,
+  lastWatchedEpisode: 5,
+  lastWatchedAt: new Date("2026-07-01T00:00:00.000Z"),
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+  ...overrides,
+});
+
+describe("up next inbox helpers", () => {
+  it("builds autoplay href from next unwatched coordinates", () => {
+    expect(
+      buildUpNextHref(1399, { seasonNumber: 2, episodeNumber: 1 }, 1, 5),
+    ).toBe("/tvshows/1399?season=2&episode=1&autoplay=true");
+  });
+
+  it("falls back to the next episode after last watched progress", () => {
+    expect(buildUpNextHref(1399, null, 1, 5)).toBe(
+      "/tvshows/1399?season=1&episode=6&autoplay=true",
+    );
+  });
+
+  it("only keeps watching tv titles with unwatched aired episodes", () => {
+    const watchlist = [
+      watchingTvItem(1),
+      watchingTvItem(2, { status: "completed" }),
+      watchingTvItem(3, { mediaType: "movie" }),
+    ];
+
+    const episodeData: Record<number, EpisodeInfo> = {
+      1: baseEpisodeInfo(),
+      2: baseEpisodeInfo(),
+      3: baseEpisodeInfo(),
+    };
+
+    expect(isUpNextInboxCandidate(watchlist[0], episodeData[1])).toBe(true);
+    expect(isUpNextInboxCandidate(watchlist[1], episodeData[2])).toBe(false);
+    expect(isUpNextInboxCandidate(watchlist[2], episodeData[3])).toBe(false);
+
+    const candidates = collectUpNextCandidates(watchlist, episodeData);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.contentId).toBe(1);
+  });
+});
+
+describe("collectWatchHistoryStubs", () => {
+  it("includes finished movies and non-watching watchlist rows", () => {
+    const watchlist: WatchlistItem[] = [
+      {
+        id: "completed",
+        userId: "u1",
+        contentId: 2,
+        mediaType: "movie",
+        status: "completed",
+        lastWatchedSeason: null,
+        lastWatchedEpisode: null,
+        lastWatchedAt: new Date("2026-07-03T12:00:00.000Z"),
+        createdAt: new Date("2026-06-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-07-03T12:00:00.000Z"),
+      },
+    ];
+
+    const stubs = collectWatchHistoryStubs({
+      playback: [
+        {
+          mediaType: "movie",
+          contentId: 1,
+          watched: 5900,
+          duration: 6000,
+          updatedAt: 100,
+          storageKey: "movie:1::",
+        },
+      ],
+      watchlist,
+      limit: WATCH_HISTORY_LIMIT,
+    });
+
+    expect(stubs).toHaveLength(2);
+    expect(stubs.map((stub) => stub.contentId)).toEqual([2, 1]);
+  });
+});

--- a/app/api/watchlist/check-episodes/route.ts
+++ b/app/api/watchlist/check-episodes/route.ts
@@ -57,14 +57,20 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const scope = request.nextUrl.searchParams.get("scope");
     const tvShows = await db
       .select()
       .from(watchlist)
       .where(and(eq(watchlist.userId, userId), eq(watchlist.mediaType, "tv")));
 
+    const scopedShows =
+      scope === "watching"
+        ? tvShows.filter((item) => item.status === "watching")
+        : tvShows;
+
     const episodeData: Record<number, EpisodeInfo> = {};
 
-    const resolved = await runInChunks(tvShows, async (item) => {
+    const resolved = await runInChunks(scopedShows, async (item) => {
       const cacheKey = makeCacheKey(userId, item);
       let episodeInfo = getCached(cacheKey);
 

--- a/app/history/history-client.tsx
+++ b/app/history/history-client.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { RecentlyWatchedCard } from "@/components/home/recently-watched-card";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useWatchHistory } from "@/hooks/use-watch-history";
+import type { RecentlyWatchedScope } from "@/lib/playback/recently-watched";
+import Link from "next/link";
+import { useState } from "react";
+
+const HISTORY_SCOPES = [
+  { value: "all", label: "All" },
+  { value: "movie", label: "Movies" },
+  { value: "tv", label: "TV Shows" },
+  { value: "anime", label: "Anime" },
+] as const satisfies ReadonlyArray<{
+  value: RecentlyWatchedScope;
+  label: string;
+}>;
+
+function HistoryGridFallback() {
+  return (
+    <div
+      className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(100%,320px),1fr))]"
+      aria-hidden
+    >
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Skeleton key={index} className="aspect-video rounded-xs" />
+      ))}
+    </div>
+  );
+}
+
+export function HistoryClient() {
+  const [scope, setScope] = useState<RecentlyWatchedScope>("all");
+  const { items, isLoading } = useWatchHistory(scope);
+
+  return (
+    <div className="relative mx-auto min-h-[calc(100vh-7rem)] w-full max-w-7xl px-4 pt-10 pb-14">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[70vh] bg-linear-to-b from-black/80 via-black/70 to-transparent" />
+
+      <div className="overflow-hidden rounded-lg border border-white/10 bg-background/82 shadow-xl shadow-black/20 backdrop-blur-xl">
+        <div className="border-b border-white/10 px-4 py-5 md:px-6">
+          <div className="space-y-1.5">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+              Watch History
+            </h1>
+            <p className="max-w-xl text-sm leading-5 text-zinc-300">
+              Everything you have started on this device, plus synced progress
+              when you are signed in.
+            </p>
+          </div>
+        </div>
+
+        <div className="border-b border-white/10 bg-white/[0.02] px-4 py-4 md:px-6">
+          <Tabs
+            value={scope}
+            onValueChange={(value) => setScope(value as RecentlyWatchedScope)}
+            className="w-full md:w-auto"
+          >
+            <TabsList className="h-9 w-full rounded-md bg-black/35 p-1 md:w-auto">
+              {HISTORY_SCOPES.map((entry) => (
+                <TabsTrigger
+                  key={entry.value}
+                  value={entry.value}
+                  className="h-7 flex-1 rounded-sm px-3 text-sm data-[state=active]:bg-white data-[state=active]:text-black md:flex-none"
+                >
+                  {entry.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
+
+        <div className="px-4 py-5 md:px-6">
+          {isLoading ? (
+            <HistoryGridFallback />
+          ) : items.length === 0 ? (
+            <div className="py-12 text-center text-muted-foreground">
+              <p className="text-lg">No watch history yet</p>
+              <p className="mt-2 text-sm">
+                Start something and it will show up here.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild variant="chrome" size="lg">
+                  <Link href="/movies">Browse Movies</Link>
+                </Button>
+                <Button asChild variant="chrome" size="lg">
+                  <Link href="/tvshows">Browse TV Shows</Link>
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(100%,320px),1fr))]">
+              {items.map((item, index) => (
+                <RecentlyWatchedCard
+                  key={`${item.mediaType}-${item.contentId}-${item.updatedAt}`}
+                  item={item}
+                  priority={index <= 3}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,20 @@
+import { StaticHero } from "@/components/hero/hero-static";
+import { ContentContainer } from "@/components/layout/content-container";
+import type { Metadata } from "next";
+import { HistoryClient } from "./history-client";
+
+export const metadata: Metadata = {
+  title: "Watch History | NyumatFlix",
+  description: "Browse everything you have watched on NyumatFlix",
+};
+
+export default function HistoryPage() {
+  return (
+    <div className="flex min-h-dvh w-full flex-col">
+      <StaticHero imageUrl="/movie-banner.webp" title="" route="" />
+      <ContentContainer className="z-10 flex w-full flex-1 flex-col items-center">
+        <HistoryClient />
+      </ContentContainer>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import {
   CatalogSpotlightFallback,
   RecentlyWatchedRowFallback,
 } from "@/components/catalog/catalog-suspense-fallbacks";
+import { HomeBecauseYouWatched } from "@/components/home/because-you-watched-row";
 import {
   HomeCollectionsSection,
   HomeFeaturedMovie,
@@ -19,6 +20,7 @@ import {
   HomeTrendingTvHeroes,
 } from "@/components/home/home-sections";
 import { HomeRecentlyWatched } from "@/components/home/recently-watched-row";
+import { HomeUpNextInbox } from "@/components/home/up-next-inbox-row";
 import { ContentContainer } from "@/components/layout/content-container";
 import { PageContainer } from "@/components/layout/page-container";
 import { siteConfig } from "@/config/site";
@@ -75,6 +77,14 @@ export default function Home() {
 
               <Suspense fallback={<RecentlyWatchedRowFallback />}>
                 <HomeRecentlyWatched />
+              </Suspense>
+
+              <Suspense fallback={<RecentlyWatchedRowFallback />}>
+                <HomeUpNextInbox />
+              </Suspense>
+
+              <Suspense fallback={<CatalogRowFallback />}>
+                <HomeBecauseYouWatched />
               </Suspense>
 
               <Suspense fallback={<CatalogRowFallback />}>

--- a/components/brand-logo.tsx
+++ b/components/brand-logo.tsx
@@ -21,6 +21,7 @@ export type BrandLogoPlacement =
   | "mobile-menu"
   | "auth"
   | "auth-compact"
+  | "onboarding"
   | "static";
 
 type PlacementConfig = {
@@ -65,6 +66,13 @@ const PLACEMENT_CONFIG: Record<BrandLogoPlacement, PlacementConfig> = {
     linked: true,
     wrapperClassName: "mb-8 flex justify-center lg:hidden",
     linkClassName: "inline-flex items-center",
+    ariaLabel: `${BRAND_NAME} home`,
+  },
+  onboarding: {
+    size: "lg",
+    linked: true,
+    linkClassName: "inline-flex items-center justify-center text-white",
+    wrapperClassName: "flex justify-center",
     ariaLabel: `${BRAND_NAME} home`,
   },
   static: {

--- a/components/hero/hero-static.tsx
+++ b/components/hero/hero-static.tsx
@@ -265,12 +265,14 @@ export function StaticHero({
     pathname.includes("/ad-free");
   const isWatchlistPage = pathname.includes("/watchlist");
   const isSettingsPage = pathname.includes("/settings");
+  const isHistoryPage = pathname.startsWith("/history");
   const isFullPageBackground =
     isSearchPage ||
     isBrowsePage ||
     isLegalPage ||
     isWatchlistPage ||
     isSettingsPage ||
+    isHistoryPage ||
     isCatalogPage;
 
   return (
@@ -281,7 +283,7 @@ export function StaticHero({
       logo={logo}
       hideTitle={hideTitle}
       overlayClassName={
-        isWatchlistPage || isSettingsPage
+        isWatchlistPage || isSettingsPage || isHistoryPage
           ? "bg-black/90"
           : isCatalogPage
             ? "bg-black/80"

--- a/components/home/because-you-watched-row.tsx
+++ b/components/home/because-you-watched-row.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { CatalogRowFallback } from "@/components/catalog/catalog-suspense-fallbacks";
+import { TrendCarousel } from "@/components/trend/trend-client";
+import { useBecauseYouWatched } from "@/hooks/use-because-you-watched";
+
+export function BecauseYouWatchedRow() {
+  const { row, isLoading } = useBecauseYouWatched();
+
+  if (isLoading) {
+    return <CatalogRowFallback />;
+  }
+
+  if (!row || row.items.length === 0) {
+    return null;
+  }
+
+  return (
+    <TrendCarousel
+      title="Because you watched"
+      description={row.seedTitle}
+      items={row.items}
+      type={row.mediaType}
+    />
+  );
+}
+
+export function HomeBecauseYouWatched() {
+  return <BecauseYouWatchedRow />;
+}

--- a/components/home/home-wide-carousel-row.tsx
+++ b/components/home/home-wide-carousel-row.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Carousel,
+  CarouselApi,
+  CarouselContent,
+  CarouselItem,
+} from "@/components/ui/carousel";
+import { cn } from "@/lib/utils";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState, type ReactNode } from "react";
+
+export const homeWideCarouselItemClassName =
+  "basis-[85%] pl-3 sm:basis-[70%] md:basis-[42%] lg:basis-[32%] xl:basis-[28%]";
+
+type HomeWideCarouselRowProps<T> = {
+  ariaLabel: string;
+  title: string;
+  description?: string;
+  actionHref?: string;
+  actionLabel?: string;
+  action?: ReactNode;
+  items: T[];
+  getItemKey: (item: T, index: number) => string;
+  renderItem: (item: T, index: number) => ReactNode;
+};
+
+export function HomeWideCarouselRow<T>({
+  ariaLabel,
+  title,
+  description,
+  actionHref,
+  actionLabel = "More",
+  action,
+  items,
+  getItemKey,
+  renderItem,
+}: HomeWideCarouselRowProps<T>) {
+  const [api, setApi] = useState<CarouselApi>();
+  const [pageCount, setPageCount] = useState(0);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+
+  useEffect(() => {
+    if (!api) return;
+
+    const sync = () => {
+      const snaps = api.scrollSnapList();
+      setPageCount(snaps.length);
+      setPageIndex(api.selectedScrollSnap());
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    };
+
+    sync();
+    api.on("select", sync);
+    api.on("reInit", sync);
+
+    return () => {
+      api.off("select", sync);
+      api.off("reInit", sync);
+    };
+  }, [api, items.length]);
+
+  return (
+    <section
+      aria-label={ariaLabel}
+      className="animate-in fade-in slide-in-from-bottom-1 duration-500 fill-mode-both"
+    >
+      <Carousel
+        opts={{
+          align: "start",
+          slidesToScroll: "auto",
+          dragFree: true,
+        }}
+        setApi={setApi}
+      >
+        <div className="mb-4 flex items-center justify-between gap-3 rounded-md p-2 pr-3 md:justify-start md:gap-4 md:pr-4">
+          <div className="min-w-0 flex-1 md:mr-32">
+            <h2 className="truncate text-lg font-medium md:text-base">
+              {title}
+            </h2>
+            {description ? (
+              <p className="hidden truncate text-sm text-muted-foreground xl:block">
+                {description}
+              </p>
+            ) : null}
+          </div>
+
+          {action ??
+            (actionHref ? (
+              <Link
+                href={actionHref}
+                className={cn(
+                  buttonVariants({ size: "sm", variant: "outline" }),
+                  "ml-auto shrink-0",
+                )}
+                prefetch={false}
+              >
+                {actionLabel}
+              </Link>
+            ) : null)}
+
+          <div className="ml-4 hidden shrink-0 items-center gap-2 md:flex">
+            {pageCount > 0 ? (
+              <p
+                className="mr-4 text-xs text-muted-foreground"
+                aria-live="polite"
+              >
+                <span className="font-bold text-foreground">
+                  {pageIndex + 1}
+                </span>
+                <span> / </span>
+                <span>{pageCount}</span>
+              </p>
+            ) : null}
+
+            <Button
+              type="button"
+              disabled={!canScrollPrev}
+              onClick={() => api?.scrollPrev()}
+              size="sm"
+              variant="outline"
+              aria-label={`Previous page of ${title.toLowerCase()}`}
+            >
+              <ArrowLeft className="size-3" />
+              <span className="sr-only">Previous page</span>
+            </Button>
+            <Button
+              type="button"
+              disabled={!canScrollNext}
+              onClick={() => api?.scrollNext()}
+              size="sm"
+              variant="outline"
+              aria-label={`Next page of ${title.toLowerCase()}`}
+            >
+              <ArrowRight className="size-3" />
+              <span className="sr-only">Next page</span>
+            </Button>
+          </div>
+        </div>
+
+        <CarouselContent className="-ml-3">
+          {items.map((item, index) => (
+            <CarouselItem
+              key={getItemKey(item, index)}
+              className={homeWideCarouselItemClassName}
+            >
+              {renderItem(item, index)}
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </Carousel>
+    </section>
+  );
+}

--- a/components/home/recently-watched-card.tsx
+++ b/components/home/recently-watched-card.tsx
@@ -2,7 +2,9 @@
 
 import { MarkContinueWatchingCompleteControl } from "@/components/home/mark-continue-watching-complete-control";
 import { useHoverSound } from "@/components/providers/hover-sound-provider";
+import { EpisodeIndicator } from "@/components/watchlist/watchlist";
 import { Icons } from "@/lib/icons";
+import type { EpisodeInfo } from "@/lib/domain/episodes";
 import type { RecentlyWatchedItem } from "@/lib/playback/recently-watched";
 import { cn } from "@/lib/utils";
 import { tmdbImage } from "@/tmdb/utils";
@@ -15,6 +17,9 @@ export interface RecentlyWatchedCardProps {
   priority?: boolean;
   isMarkCompletePending?: boolean;
   onMarkComplete?: () => void | Promise<void>;
+  showProgress?: boolean;
+  playAriaLabel?: string;
+  episodeInfo?: EpisodeInfo | null;
 }
 
 const continueWatchingProgressFillClass = "bg-pink-500";
@@ -26,6 +31,9 @@ export function RecentlyWatchedCard({
   priority = false,
   isMarkCompletePending = false,
   onMarkComplete,
+  showProgress = true,
+  playAriaLabel,
+  episodeInfo = null,
 }: RecentlyWatchedCardProps) {
   const playHoverSound = useHoverSound();
   const backdropUrl = item.backdropPath
@@ -92,38 +100,49 @@ export function RecentlyWatchedCard({
               </>
             ) : null}
           </div>
+          {episodeInfo && item.mediaType === "tv" ? (
+            <div className="pointer-events-none pt-0.5">
+              <EpisodeIndicator
+                contentId={item.contentId}
+                mediaType="tv"
+                episodeInfo={episodeInfo}
+              />
+            </div>
+          ) : null}
         </div>
       </div>
 
-      <div
-        className={cn(
-          "pointer-events-none absolute inset-x-0 bottom-0 z-30 h-[3px]",
-          continueWatchingProgressTrackClass,
-        )}
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={progressPercent ?? undefined}
-        aria-label={
-          progressPercent != null
-            ? `${progressPercent}% watched`
-            : "Watch progress unavailable"
-        }
-      >
+      {showProgress ? (
         <div
           className={cn(
-            "h-full transition-[width] duration-500",
-            progressPercent == null
-              ? cn("w-[6%]", continueWatchingProgressFallbackFillClass)
-              : continueWatchingProgressFillClass,
+            "pointer-events-none absolute inset-x-0 bottom-0 z-30 h-[3px]",
+            continueWatchingProgressTrackClass,
           )}
-          style={
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progressPercent ?? undefined}
+          aria-label={
             progressPercent != null
-              ? { width: `${Math.max(progressPercent, 2)}%` }
-              : undefined
+              ? `${progressPercent}% watched`
+              : "Watch progress unavailable"
           }
-        />
-      </div>
+        >
+          <div
+            className={cn(
+              "h-full transition-[width] duration-500",
+              progressPercent == null
+                ? cn("w-[6%]", continueWatchingProgressFallbackFillClass)
+                : continueWatchingProgressFillClass,
+            )}
+            style={
+              progressPercent != null
+                ? { width: `${Math.max(progressPercent, 2)}%` }
+                : undefined
+            }
+          />
+        </div>
+      ) : null}
 
       {onMarkComplete ? (
         <MarkContinueWatchingCompleteControl
@@ -138,7 +157,7 @@ export function RecentlyWatchedCard({
         <Link
           href={item.href}
           className="pointer-events-auto flex size-20 cursor-pointer items-center justify-center rounded-full opacity-100 transition-opacity duration-300 md:opacity-0 md:group-hover:opacity-100"
-          aria-label={`Continue watching ${item.title}`}
+          aria-label={playAriaLabel ?? `Continue watching ${item.title}`}
           prefetch={false}
         >
           <Icons.play

--- a/components/home/up-next-inbox-row.tsx
+++ b/components/home/up-next-inbox-row.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { RecentlyWatchedRowFallback } from "@/components/catalog/catalog-suspense-fallbacks";
+import { HomeWideCarouselRow } from "@/components/home/home-wide-carousel-row";
+import { RecentlyWatchedCard } from "@/components/home/recently-watched-card";
+import {
+  useUpNextInbox,
+  type UpNextInboxItem,
+} from "@/hooks/use-up-next-inbox";
+
+export function UpNextInboxRow() {
+  const { items, isLoading, isSignedIn } = useUpNextInbox();
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  if (isLoading) {
+    return <RecentlyWatchedRowFallback />;
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <HomeWideCarouselRow<UpNextInboxItem>
+      ariaLabel="Up next"
+      title="Up Next"
+      description="Unwatched episodes from shows you are watching"
+      actionHref="/watchlist"
+      actionLabel="Watchlist"
+      items={items}
+      getItemKey={(item) => `${item.contentId}-${item.upNextHref}`}
+      renderItem={(item, index) => (
+        <RecentlyWatchedCard
+          item={item}
+          priority={index <= 2}
+          showProgress={false}
+          playAriaLabel={`Play next episode of ${item.title}`}
+          episodeInfo={item.episodeInfo}
+        />
+      )}
+    />
+  );
+}
+
+export function HomeUpNextInbox() {
+  return <UpNextInboxRow />;
+}

--- a/components/layout/nav/navbar-mobile-navigation.tsx
+++ b/components/layout/nav/navbar-mobile-navigation.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import {
   Check,
   ChevronRight,
+  History,
   List,
   LogIn,
   LogOut,
@@ -325,6 +326,18 @@ const LoggedInProfileCard = ({
             {watchlistSummary.total}
           </span>
         ) : null}
+      </span>
+      <ChevronRight className="size-4 text-white/45" />
+    </Link>
+
+    <Link
+      href="/history"
+      onClick={onNavigate}
+      className="flex items-center justify-between border-t border-white/10 px-4 py-3 text-sm font-medium text-white transition hover:bg-white/10"
+    >
+      <span className="inline-flex items-center gap-2">
+        <History className="size-4 text-primary" />
+        Watch History
       </span>
       <ChevronRight className="size-4 text-white/45" />
     </Link>

--- a/components/layout/nav/navbar-server.tsx
+++ b/components/layout/nav/navbar-server.tsx
@@ -1,7 +1,5 @@
-import { auth } from "@/auth";
 import { NavbarClient } from "./navbar-client";
 
-export const NavbarServer = async () => {
-  const session = await auth();
-  return <NavbarClient session={session} />;
+export const NavbarServer = () => {
+  return <NavbarClient />;
 };

--- a/components/layout/nav/user-avatar.tsx
+++ b/components/layout/nav/user-avatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { List, LogOut, Settings } from "lucide-react";
+import { History, List, LogOut, Settings } from "lucide-react";
 import { Session } from "next-auth";
 import { signOut, useSession } from "next-auth/react";
 import Link from "next/link";
@@ -102,6 +102,15 @@ export const UserAvatar = ({ session, triggerClassName }: UserAvatarProps) => {
           >
             <List className="mr-2 h-4 w-4" />
             <span>Watchlist</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild className={userMenuItemClassName}>
+          <Link
+            href="/history"
+            className="flex w-full cursor-pointer items-center"
+          >
+            <History className="mr-2 h-4 w-4" />
+            <span>Watch history</span>
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem

--- a/hooks/use-because-you-watched.ts
+++ b/hooks/use-because-you-watched.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { fetchBecauseYouWatchedRow } from "@/lib/personalization/because-you-watched";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  collectLocalRecentlyWatchedStubs,
+  RECENTLY_WATCHED_LIMIT,
+} from "@/lib/playback/recently-watched";
+import type { WatchlistItem } from "@/lib/domain/watchlist";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+async function fetchWatchlistItems(): Promise<WatchlistItem[]> {
+  const response = await fetch("/api/watchlist");
+  if (response.status === 401) {
+    return [];
+  }
+  if (!response.ok) {
+    throw new Error("Failed to fetch watchlist");
+  }
+  const data = (await response.json()) as { items?: WatchlistItem[] };
+  return data.items ?? [];
+}
+
+export function useBecauseYouWatched() {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  const watchlistQuery = useQuery({
+    queryKey: queryKeys.watchlist(),
+    queryFn: fetchWatchlistItems,
+    staleTime: 60_000,
+  });
+
+  const stubs = useMemo(() => {
+    if (!hydrated) {
+      return null;
+    }
+
+    return collectLocalRecentlyWatchedStubs(watchlistQuery.data ?? [], {
+      limit: RECENTLY_WATCHED_LIMIT,
+    });
+  }, [hydrated, watchlistQuery.data]);
+
+  const stubsKey = useMemo(
+    () =>
+      stubs
+        ?.map(
+          (stub) =>
+            `${stub.mediaType}:${stub.contentId}:${stub.updatedAt}:${stub.seasonNumber ?? ""}:${stub.episodeNumber ?? ""}`,
+        )
+        .join("|") ?? "",
+    [stubs],
+  );
+
+  const rowQuery = useQuery({
+    queryKey: queryKeys.becauseYouWatched(stubsKey),
+    queryFn: async () => {
+      if (!stubs?.length) {
+        return null;
+      }
+
+      const excludeIds = new Set(stubs.map((stub) => stub.contentId));
+      return fetchBecauseYouWatchedRow(stubs, excludeIds);
+    },
+    enabled: hydrated && Boolean(stubs?.length),
+    staleTime: 30 * 60_000,
+  });
+
+  const isLoading =
+    !hydrated ||
+    watchlistQuery.isLoading ||
+    (Boolean(stubs?.length) && rowQuery.isLoading);
+
+  return {
+    row: rowQuery.data ?? null,
+    isLoading,
+  };
+}

--- a/hooks/use-up-next-inbox.ts
+++ b/hooks/use-up-next-inbox.ts
@@ -1,0 +1,186 @@
+"use client";
+
+import type { WatchlistItem } from "@/lib/domain/watchlist";
+import type { EpisodeInfo } from "@/lib/domain/episodes";
+import {
+  buildUpNextHref,
+  collectUpNextCandidates,
+  parseEpisodeDataResponse,
+  type UpNextCandidate,
+} from "@/lib/personalization/up-next";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  toRecentlyWatchedItem,
+  type RecentlyWatchedItem,
+} from "@/lib/playback/recently-watched";
+import { isAnime } from "@/utils/anilist-helpers";
+import { useQuery } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import { useMemo } from "react";
+
+export type UpNextInboxItem = RecentlyWatchedItem & {
+  episodeInfo: EpisodeInfo;
+  upNextHref: string;
+};
+
+type MediaDetailResponse = {
+  id?: number;
+  name?: string;
+  backdrop_path?: string | null;
+  poster_path?: string | null;
+  vote_average?: number;
+  first_air_date?: string;
+  genre_ids?: number[];
+  genres?: Array<{ id: number; name?: string }>;
+};
+
+async function fetchWatchlistItems(): Promise<WatchlistItem[]> {
+  const response = await fetch("/api/watchlist");
+  if (response.status === 401) {
+    return [];
+  }
+  if (!response.ok) {
+    throw new Error("Failed to fetch watchlist");
+  }
+  const data = (await response.json()) as { items?: WatchlistItem[] };
+  return data.items ?? [];
+}
+
+async function fetchUpNextEpisodeData(): Promise<Record<number, EpisodeInfo>> {
+  const response = await fetch("/api/watchlist/check-episodes?scope=watching");
+  if (response.status === 401) {
+    return {};
+  }
+  if (!response.ok) {
+    throw new Error("Failed to fetch up next episodes");
+  }
+
+  const data = (await response.json()) as {
+    episodeData?: Record<string, unknown>;
+  };
+
+  return parseEpisodeDataResponse(data.episodeData ?? {});
+}
+
+async function enrichUpNextCandidate(
+  candidate: UpNextCandidate,
+): Promise<UpNextInboxItem | null> {
+  const response = await fetch(`/api/tv/${candidate.contentId}`);
+  if (!response.ok) {
+    return null;
+  }
+
+  const detail = (await response.json()) as MediaDetailResponse;
+  if (detail.id !== candidate.contentId) {
+    return null;
+  }
+
+  const title = detail.name;
+  if (!title) {
+    return null;
+  }
+
+  const stub = {
+    mediaType: "tv" as const,
+    contentId: candidate.contentId,
+    seasonNumber:
+      candidate.episodeInfo.nextUnwatchedEpisode?.seasonNumber ??
+      candidate.watchlistItem.lastWatchedSeason ??
+      undefined,
+    episodeNumber:
+      candidate.episodeInfo.nextUnwatchedEpisode?.episodeNumber ??
+      candidate.watchlistItem.lastWatchedEpisode ??
+      undefined,
+    progressRatio: null,
+    updatedAt: candidate.watchlistItem.lastWatchedAt
+      ? new Date(candidate.watchlistItem.lastWatchedAt).getTime()
+      : new Date(candidate.watchlistItem.updatedAt).getTime(),
+  };
+
+  const item = toRecentlyWatchedItem(stub, {
+    title,
+    backdropPath: detail.backdrop_path,
+    posterPath: detail.poster_path,
+    voteAverage: detail.vote_average,
+    year: detail.first_air_date?.substring(0, 4),
+    isAnime: isAnime(detail),
+  });
+
+  const upNextHref = buildUpNextHref(
+    candidate.contentId,
+    candidate.episodeInfo.nextUnwatchedEpisode,
+    candidate.watchlistItem.lastWatchedSeason,
+    candidate.watchlistItem.lastWatchedEpisode,
+  );
+
+  return {
+    ...item,
+    href: upNextHref,
+    episodeInfo: candidate.episodeInfo,
+    upNextHref,
+  };
+}
+
+export function useUpNextInbox() {
+  const { data: session, status: sessionStatus } = useSession();
+  const isSignedIn = Boolean(session?.user?.id);
+
+  const watchlistQuery = useQuery({
+    queryKey: queryKeys.watchlist(),
+    queryFn: fetchWatchlistItems,
+    enabled: isSignedIn,
+    staleTime: 60_000,
+  });
+
+  const episodeQuery = useQuery({
+    queryKey: queryKeys.upNextInbox(),
+    queryFn: fetchUpNextEpisodeData,
+    enabled: isSignedIn,
+    staleTime: 60 * 60_000,
+  });
+
+  const candidates = useMemo(
+    () =>
+      collectUpNextCandidates(
+        watchlistQuery.data ?? [],
+        episodeQuery.data ?? {},
+      ),
+    [watchlistQuery.data, episodeQuery.data],
+  );
+
+  const candidatesKey = useMemo(
+    () =>
+      candidates
+        .map(
+          (candidate) =>
+            `${candidate.contentId}:${candidate.episodeInfo.unwatchedEpisodeCount}:${candidate.episodeInfo.nextUnwatchedEpisode?.seasonNumber ?? ""}:${candidate.episodeInfo.nextUnwatchedEpisode?.episodeNumber ?? ""}`,
+        )
+        .join("|"),
+    [candidates],
+  );
+
+  const itemsQuery = useQuery({
+    queryKey: [...queryKeys.upNextInbox(), "items", candidatesKey],
+    queryFn: async () => {
+      const results = await Promise.all(
+        candidates.map((candidate) => enrichUpNextCandidate(candidate)),
+      );
+      return results.filter((item): item is UpNextInboxItem => item !== null);
+    },
+    enabled: isSignedIn && candidates.length > 0,
+    staleTime: 5 * 60_000,
+  });
+
+  const isLoading =
+    sessionStatus === "loading" ||
+    (isSignedIn &&
+      (watchlistQuery.isLoading ||
+        episodeQuery.isLoading ||
+        (candidates.length > 0 && itemsQuery.isLoading)));
+
+  return {
+    items: itemsQuery.data ?? [],
+    isLoading,
+    isSignedIn,
+  };
+}

--- a/hooks/use-watch-history.ts
+++ b/hooks/use-watch-history.ts
@@ -1,0 +1,180 @@
+"use client";
+
+import type { WatchlistItem } from "@/lib/domain/watchlist";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  collectLocalWatchHistoryStubs,
+  matchesRecentlyWatchedScope,
+  mediaTypesForScope,
+  toRecentlyWatchedItem,
+  WATCH_HISTORY_LIMIT,
+  type RecentlyWatchedItem,
+  type RecentlyWatchedScope,
+  type RecentlyWatchedStub,
+} from "@/lib/playback/recently-watched";
+import { isAnime } from "@/utils/anilist-helpers";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+type MediaDetailResponse = {
+  title?: string;
+  name?: string;
+  backdrop_path?: string | null;
+  poster_path?: string | null;
+  vote_average?: number;
+  release_date?: string;
+  first_air_date?: string;
+  genre_ids?: number[];
+  genres?: Array<{ id: number; name?: string }>;
+};
+
+async function fetchWatchlistItems(): Promise<WatchlistItem[]> {
+  const response = await fetch("/api/watchlist");
+  if (response.status === 401) {
+    return [];
+  }
+  if (!response.ok) {
+    throw new Error("Failed to fetch watchlist");
+  }
+  const data = (await response.json()) as { items?: WatchlistItem[] };
+  return data.items ?? [];
+}
+
+async function fetchMediaDetail(
+  stub: RecentlyWatchedStub,
+): Promise<RecentlyWatchedItem | null> {
+  const path =
+    stub.mediaType === "movie"
+      ? `/api/movies/${stub.contentId}`
+      : `/api/tv/${stub.contentId}`;
+
+  const response = await fetch(path);
+  if (!response.ok) {
+    if (stub.title) {
+      return toRecentlyWatchedItem(stub, {
+        title: stub.title,
+        backdropPath: stub.backdropPath,
+        posterPath: stub.posterPath,
+        isAnime: false,
+      });
+    }
+    return null;
+  }
+
+  const detail = (await response.json()) as MediaDetailResponse;
+  const title =
+    stub.mediaType === "movie"
+      ? (detail.title ?? stub.title)
+      : (detail.name ?? stub.title);
+
+  if (!title) {
+    return null;
+  }
+
+  const date =
+    stub.mediaType === "movie" ? detail.release_date : detail.first_air_date;
+
+  return toRecentlyWatchedItem(stub, {
+    title,
+    backdropPath: detail.backdrop_path ?? stub.backdropPath,
+    posterPath: detail.poster_path ?? stub.posterPath,
+    voteAverage: detail.vote_average,
+    year: date?.substring(0, 4),
+    isAnime: isAnime(detail),
+  });
+}
+
+async function enrichStubs(
+  stubs: RecentlyWatchedStub[],
+): Promise<RecentlyWatchedItem[]> {
+  const results: RecentlyWatchedItem[] = [];
+  const chunkSize = 8;
+
+  for (let index = 0; index < stubs.length; index += chunkSize) {
+    const chunk = stubs.slice(index, index + chunkSize);
+    const chunkResults = await Promise.all(
+      chunk.map((stub) => fetchMediaDetail(stub)),
+    );
+
+    for (const item of chunkResults) {
+      if (item) {
+        results.push(item);
+      }
+    }
+  }
+
+  return results;
+}
+
+export function useWatchHistory(scope: RecentlyWatchedScope = "all") {
+  const [hydrated, setHydrated] = useState(false);
+  const mediaTypes = mediaTypesForScope(scope);
+  const collectLimit =
+    scope === "tv" || scope === "anime"
+      ? WATCH_HISTORY_LIMIT * 2
+      : WATCH_HISTORY_LIMIT;
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  const watchlistQuery = useQuery({
+    queryKey: queryKeys.watchlist(),
+    queryFn: fetchWatchlistItems,
+    staleTime: 60_000,
+  });
+
+  const stubs = useMemo(() => {
+    if (!hydrated) {
+      return null;
+    }
+
+    return collectLocalWatchHistoryStubs(watchlistQuery.data ?? [], {
+      limit: collectLimit,
+      mediaTypes,
+    });
+  }, [hydrated, watchlistQuery.data, collectLimit, mediaTypes]);
+
+  const stubsKey = useMemo(
+    () =>
+      stubs
+        ?.map(
+          (stub) =>
+            `${stub.mediaType}:${stub.contentId}:${stub.seasonNumber ?? ""}:${stub.episodeNumber ?? ""}:${stub.updatedAt}`,
+        )
+        .join("|") ?? "",
+    [stubs],
+  );
+
+  const itemsQuery = useQuery({
+    queryKey: queryKeys.watchHistory(scope, stubsKey),
+    queryFn: () => enrichStubs(stubs ?? []),
+    enabled: stubs !== null && stubs.length > 0,
+    staleTime: 5 * 60_000,
+  });
+
+  const items = useMemo(() => {
+    if (!stubs?.length) {
+      return [];
+    }
+
+    const stubKeys = new Set(
+      stubs.map((stub) => `${stub.mediaType}:${stub.contentId}`),
+    );
+
+    return (itemsQuery.data ?? [])
+      .filter((item) => stubKeys.has(`${item.mediaType}:${item.contentId}`))
+      .filter((item) => matchesRecentlyWatchedScope(item, scope))
+      .slice(0, WATCH_HISTORY_LIMIT);
+  }, [itemsQuery.data, scope, stubs]);
+
+  const isLoading =
+    !hydrated ||
+    watchlistQuery.isLoading ||
+    (Boolean(stubs?.length) && itemsQuery.isLoading);
+
+  return {
+    items,
+    isLoading,
+  };
+}

--- a/lib/domain/episodes.ts
+++ b/lib/domain/episodes.ts
@@ -1,6 +1,14 @@
+export type EpisodeCoordinates = {
+  seasonNumber: number;
+  episodeNumber: number;
+};
+
 export interface EpisodeInfo {
   hasNewEpisodes: boolean;
   newEpisodeCount: number;
+  hasUnwatchedEpisodes: boolean;
+  unwatchedEpisodeCount: number;
+  nextUnwatchedEpisode: EpisodeCoordinates | null;
   nextEpisodeDate: Date | null;
   countdown: string | null;
   latestEpisodeAirDate: Date | null;

--- a/lib/personalization/because-you-watched.ts
+++ b/lib/personalization/because-you-watched.ts
@@ -1,0 +1,125 @@
+import { takeUniqueByIdInOrder } from "@/lib/catalog-page-dedupe";
+import {
+  fetchMovieRecommendationsPageClient,
+  fetchTvRecommendationsPageClient,
+} from "@/lib/media-detail-tab-client";
+import type { RecentlyWatchedStub } from "@/lib/playback/recently-watched";
+import type { MovieWithMediaType, TvShowWithMediaType } from "@/tmdb/models";
+
+export const BECAUSE_YOU_WATCHED_LIMIT = 20;
+
+export type BecauseYouWatchedResult =
+  | {
+      seedTitle: string;
+      mediaType: "movie";
+      items: MovieWithMediaType[];
+    }
+  | {
+      seedTitle: string;
+      mediaType: "tv";
+      items: TvShowWithMediaType[];
+    };
+
+type MediaDetailResponse = {
+  id?: number;
+  title?: string;
+  name?: string;
+};
+
+const isMatchingTmdbDetail = (
+  stub: RecentlyWatchedStub,
+  detail: MediaDetailResponse,
+): boolean => detail.id === stub.contentId;
+
+async function fetchSeedTitle(
+  stub: RecentlyWatchedStub,
+): Promise<string | null> {
+  const path =
+    stub.mediaType === "movie"
+      ? `/api/movies/${stub.contentId}`
+      : `/api/tv/${stub.contentId}`;
+
+  const response = await fetch(path);
+  if (!response.ok) {
+    return stub.title ?? null;
+  }
+
+  const detail = (await response.json()) as MediaDetailResponse;
+  if (!isMatchingTmdbDetail(stub, detail)) {
+    return null;
+  }
+
+  return stub.mediaType === "movie"
+    ? (detail.title ?? stub.title ?? null)
+    : (detail.name ?? stub.title ?? null);
+}
+
+export async function fetchBecauseYouWatchedRow(
+  stubs: RecentlyWatchedStub[],
+  excludeIds: ReadonlySet<number>,
+): Promise<BecauseYouWatchedResult | null> {
+  const seen = new Set(excludeIds);
+
+  for (const stub of stubs) {
+    const seedTitle = await fetchSeedTitle(stub);
+    if (!seedTitle) {
+      continue;
+    }
+
+    if (stub.mediaType === "movie") {
+      const page = await fetchMovieRecommendationsPageClient(
+        String(stub.contentId),
+        "1",
+      );
+      const items = takeUniqueByIdInOrder(
+        (page.results ?? []).map(
+          (movie) =>
+            ({
+              ...movie,
+              media_type: "movie",
+            }) satisfies MovieWithMediaType,
+        ),
+        seen,
+        BECAUSE_YOU_WATCHED_LIMIT,
+      );
+
+      if (items.length === 0) {
+        continue;
+      }
+
+      return {
+        seedTitle,
+        mediaType: "movie",
+        items,
+      };
+    }
+
+    const page = await fetchTvRecommendationsPageClient(
+      String(stub.contentId),
+      "1",
+    );
+    const items = takeUniqueByIdInOrder(
+      (page.results ?? []).map(
+        (show) =>
+          ({
+            ...show,
+            media_type: "tv",
+          }) satisfies TvShowWithMediaType,
+      ),
+      seen,
+      BECAUSE_YOU_WATCHED_LIMIT,
+    );
+
+    if (items.length === 0) {
+      continue;
+    }
+
+    return {
+      seedTitle,
+      mediaType: "tv",
+      items,
+    };
+  }
+
+  return null;
+}

--- a/lib/personalization/up-next.ts
+++ b/lib/personalization/up-next.ts
@@ -1,0 +1,86 @@
+import type { EpisodeCoordinates, EpisodeInfo } from "@/lib/domain/episodes";
+import type { WatchlistItem } from "@/lib/domain/watchlist";
+
+export type UpNextCandidate = {
+  contentId: number;
+  watchlistItem: WatchlistItem;
+  episodeInfo: EpisodeInfo;
+};
+
+export const buildUpNextHref = (
+  contentId: number,
+  nextUnwatchedEpisode: EpisodeCoordinates | null,
+  fallbackSeason?: number | null,
+  fallbackEpisode?: number | null,
+): string => {
+  if (nextUnwatchedEpisode) {
+    return `/tvshows/${contentId}?season=${nextUnwatchedEpisode.seasonNumber}&episode=${nextUnwatchedEpisode.episodeNumber}&autoplay=true`;
+  }
+
+  const season = fallbackSeason && fallbackSeason > 0 ? fallbackSeason : 1;
+  const episode =
+    fallbackEpisode && fallbackEpisode > 0 ? fallbackEpisode + 1 : 1;
+
+  return `/tvshows/${contentId}?season=${season}&episode=${episode}&autoplay=true`;
+};
+
+export const isUpNextInboxCandidate = (
+  item: WatchlistItem,
+  episodeInfo: EpisodeInfo | undefined,
+): episodeInfo is EpisodeInfo =>
+  item.mediaType === "tv" &&
+  item.status === "watching" &&
+  Boolean(episodeInfo?.hasUnwatchedEpisodes);
+
+export const collectUpNextCandidates = (
+  watchlistItems: WatchlistItem[],
+  episodeData: Record<number, EpisodeInfo>,
+): UpNextCandidate[] =>
+  watchlistItems
+    .filter((item) => isUpNextInboxCandidate(item, episodeData[item.contentId]))
+    .map((item) => ({
+      contentId: item.contentId,
+      watchlistItem: item,
+      episodeInfo: episodeData[item.contentId],
+    }))
+    .sort((left, right) => {
+      const leftDate = left.episodeInfo.latestEpisodeAirDate?.getTime() ?? 0;
+      const rightDate = right.episodeInfo.latestEpisodeAirDate?.getTime() ?? 0;
+      if (leftDate !== rightDate) {
+        return rightDate - leftDate;
+      }
+
+      return (
+        right.episodeInfo.unwatchedEpisodeCount -
+        left.episodeInfo.unwatchedEpisodeCount
+      );
+    });
+
+export const parseEpisodeDataResponse = (
+  raw: Record<string, unknown>,
+): Record<number, EpisodeInfo> => {
+  const parsed: Record<number, EpisodeInfo> = {};
+
+  for (const [contentId, info] of Object.entries(raw)) {
+    if (!info || typeof info !== "object") {
+      continue;
+    }
+
+    const typed = info as EpisodeInfo & {
+      nextEpisodeDate?: string | Date | null;
+      latestEpisodeAirDate?: string | Date | null;
+    };
+
+    parsed[Number(contentId)] = {
+      ...typed,
+      nextEpisodeDate: typed.nextEpisodeDate
+        ? new Date(typed.nextEpisodeDate)
+        : null,
+      latestEpisodeAirDate: typed.latestEpisodeAirDate
+        ? new Date(typed.latestEpisodeAirDate)
+        : null,
+    };
+  }
+
+  return parsed;
+};

--- a/lib/playback/recently-watched.ts
+++ b/lib/playback/recently-watched.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/playback/progress-storage";
 
 export const RECENTLY_WATCHED_LIMIT = 12;
+export const WATCH_HISTORY_LIMIT = 100;
 export const VIDSRC_PROGRESS_STORAGE_KEY = "vidsrcwtf-Progress";
 
 export type RecentlyWatchedStub = {
@@ -216,6 +217,88 @@ const stubsFromWatchlist = (items: WatchlistItem[]): RecentlyWatchedStub[] =>
       };
     });
 
+const stubsFromWatchlistHistory = (
+  items: WatchlistItem[],
+): RecentlyWatchedStub[] =>
+  items
+    .filter(
+      (item) =>
+        item.lastWatchedAt != null ||
+        item.lastWatchedSeason != null ||
+        item.lastWatchedEpisode != null,
+    )
+    .map((item) => {
+      const updatedAt = item.lastWatchedAt
+        ? new Date(item.lastWatchedAt).getTime()
+        : new Date(item.updatedAt).getTime();
+
+      return {
+        mediaType: item.mediaType,
+        contentId: item.contentId,
+        seasonNumber: item.lastWatchedSeason ?? undefined,
+        episodeNumber: item.lastWatchedEpisode ?? undefined,
+        progressRatio: null,
+        updatedAt: Number.isFinite(updatedAt) ? updatedAt : 0,
+      };
+    });
+
+const stubsFromPlaybackHistory = (
+  playback: ListedPlaybackProgress[],
+): RecentlyWatchedStub[] =>
+  playback.map((entry) => ({
+    mediaType: entry.mediaType,
+    contentId: entry.contentId,
+    seasonNumber: entry.seasonNumber,
+    episodeNumber: entry.episodeNumber,
+    progressRatio: playbackProgressRatio(entry),
+    updatedAt: entry.updatedAt,
+  }));
+
+const stubsFromVidsrcHistory = (
+  entries: VidsrcProgressEntry[],
+): RecentlyWatchedStub[] => {
+  const stubs: RecentlyWatchedStub[] = [];
+
+  for (const entry of entries) {
+    const contentId = Number.parseInt(entry.id, 10);
+    if (!Number.isFinite(contentId) || contentId <= 0) {
+      continue;
+    }
+
+    const seasonNumber =
+      entry.type === "tv"
+        ? parseOptionalInt(entry.last_season_watched)
+        : undefined;
+    const episodeNumber =
+      entry.type === "tv"
+        ? parseOptionalInt(entry.last_episode_watched)
+        : undefined;
+
+    const progress = entry.progress;
+    const progressRatio =
+      progress &&
+      Number.isFinite(progress.watched) &&
+      Number.isFinite(progress.duration) &&
+      progress.duration > 0
+        ? playbackProgressRatio(progress)
+        : null;
+
+    stubs.push({
+      mediaType: entry.type,
+      contentId,
+      seasonNumber,
+      episodeNumber,
+      progressRatio,
+      updatedAt: entry.last_updated ?? 0,
+      title: entry.title,
+      backdropPath: entry.backdrop_path ?? null,
+      posterPath: entry.poster_path ?? null,
+    });
+  }
+
+  return stubs;
+};
+
 const mergeStub = (
   current: RecentlyWatchedStub | undefined,
   next: RecentlyWatchedStub,
@@ -297,6 +380,47 @@ export const collectLocalRecentlyWatchedStubs = (
     watchlist,
     dismissals: options.dismissals ?? readContinueWatchingDismissals(),
     limit: options.limit ?? RECENTLY_WATCHED_LIMIT,
+    mediaTypes: options.mediaTypes,
+  });
+
+export const collectWatchHistoryStubs = (input: {
+  playback?: ListedPlaybackProgress[];
+  vidsrc?: VidsrcProgressEntry[];
+  watchlist?: WatchlistItem[];
+  limit?: number;
+  mediaTypes?: readonly PlaybackMediaType[];
+}): RecentlyWatchedStub[] => {
+  const merged = new Map<string, RecentlyWatchedStub>();
+  const mediaTypes = input.mediaTypes;
+
+  const sources = [
+    ...stubsFromPlaybackHistory(input.playback ?? []),
+    ...stubsFromVidsrcHistory(input.vidsrc ?? []),
+    ...stubsFromWatchlistHistory(input.watchlist ?? []),
+  ].filter((stub) => !mediaTypes || mediaTypes.includes(stub.mediaType));
+
+  for (const stub of sources) {
+    const key = titleKey(stub.mediaType, stub.contentId);
+    merged.set(key, mergeStub(merged.get(key), stub));
+  }
+
+  return [...merged.values()]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, input.limit ?? WATCH_HISTORY_LIMIT);
+};
+
+export const collectLocalWatchHistoryStubs = (
+  watchlist: WatchlistItem[] = [],
+  options: {
+    limit?: number;
+    mediaTypes?: readonly PlaybackMediaType[];
+  } = {},
+): RecentlyWatchedStub[] =>
+  collectWatchHistoryStubs({
+    playback: listPlaybackProgress(),
+    vidsrc: readVidsrcProgressEntries(),
+    watchlist,
+    limit: options.limit ?? WATCH_HISTORY_LIMIT,
     mediaTypes: options.mediaTypes,
   });
 

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -63,6 +63,11 @@ export const queryKeys = {
 
   watchlist: () => [...queryKeys.all, "watchlist"] as const,
   watchlistSummary: () => [...queryKeys.watchlist(), "summary"] as const,
+  upNextInbox: () => [...queryKeys.watchlist(), "up-next-inbox"] as const,
+  becauseYouWatched: (stubsKey: string) =>
+    [...queryKeys.watchlist(), "because-you-watched", stubsKey] as const,
+  watchHistory: (scope: string, stubsKey: string) =>
+    [...queryKeys.watchlist(), "watch-history", scope, stubsKey] as const,
 
   serverAvailability: (key: string) =>
     [...queryKeys.all, "server-availability", key] as const,

--- a/lib/server/episode-check-service.ts
+++ b/lib/server/episode-check-service.ts
@@ -1,9 +1,44 @@
 import "server-only";
 
-import type { EpisodeInfo } from "@/lib/domain/episodes";
+import type { EpisodeCoordinates, EpisodeInfo } from "@/lib/domain/episodes";
 import { fetchSeasonDetailsServer } from "@/lib/server/tvshow-api";
 import { formatCountdown } from "@/lib/utils/countdown";
 import { tmdb } from "@/tmdb/api";
+
+const isEpisodeAfterLastWatched = (
+  seasonNumber: number,
+  episodeNumber: number,
+  lastWatchedSeason: number | null,
+  lastWatchedEpisode: number | null,
+): boolean => {
+  if (lastWatchedSeason === null || lastWatchedEpisode === null) {
+    return true;
+  }
+
+  if (seasonNumber > lastWatchedSeason) {
+    return true;
+  }
+
+  if (
+    seasonNumber === lastWatchedSeason &&
+    episodeNumber > lastWatchedEpisode
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+const compareEpisodeCoordinates = (
+  left: EpisodeCoordinates,
+  right: EpisodeCoordinates,
+): number => {
+  if (left.seasonNumber !== right.seasonNumber) {
+    return left.seasonNumber - right.seasonNumber;
+  }
+
+  return left.episodeNumber - right.episodeNumber;
+};
 
 export async function checkEpisodesForShow(
   contentId: number,
@@ -29,6 +64,8 @@ export async function checkEpisodesForShow(
     }
 
     let newEpisodeCount = 0;
+    let unwatchedEpisodeCount = 0;
+    let nextUnwatchedEpisode: EpisodeCoordinates | null = null;
     let latestEpisodeAirDate: Date | null = null;
     let nextEpisodeDate: Date | null = null;
 
@@ -74,13 +111,29 @@ export async function checkEpisodesForShow(
         if (!episode.air_date) continue;
 
         const episodeDate = new Date(episode.air_date);
-        const isNewEpisode =
-          episodeDate >= sevenDaysAgo &&
-          (lastWatchedSeason === null ||
-            lastWatchedEpisode === null ||
-            season.season_number > lastWatchedSeason ||
-            (season.season_number === lastWatchedSeason &&
-              episode.episode_number > lastWatchedEpisode));
+        const isAfterLastWatched = isEpisodeAfterLastWatched(
+          season.season_number,
+          episode.episode_number,
+          lastWatchedSeason,
+          lastWatchedEpisode,
+        );
+
+        if (isAfterLastWatched) {
+          unwatchedEpisodeCount++;
+          const candidate: EpisodeCoordinates = {
+            seasonNumber: season.season_number,
+            episodeNumber: episode.episode_number,
+          };
+
+          if (
+            !nextUnwatchedEpisode ||
+            compareEpisodeCoordinates(candidate, nextUnwatchedEpisode) < 0
+          ) {
+            nextUnwatchedEpisode = candidate;
+          }
+        }
+
+        const isNewEpisode = episodeDate >= sevenDaysAgo && isAfterLastWatched;
 
         if (isNewEpisode) {
           newEpisodeCount++;
@@ -96,10 +149,6 @@ export async function checkEpisodesForShow(
           nextEpisodeDate = new Date(nextEpisode.air_date);
         }
       }
-
-      if (newEpisodeCount > 0 && nextEpisodeDate) {
-        break;
-      }
     }
 
     let countdown: string | null = null;
@@ -110,6 +159,9 @@ export async function checkEpisodesForShow(
     return {
       hasNewEpisodes: newEpisodeCount > 0,
       newEpisodeCount,
+      hasUnwatchedEpisodes: unwatchedEpisodeCount > 0,
+      unwatchedEpisodeCount,
+      nextUnwatchedEpisode,
       nextEpisodeDate,
       countdown,
       latestEpisodeAirDate,


### PR DESCRIPTION
## Summary
- Adds **Because you watched** recommendations row on home
- Adds **Up Next** inbox for unwatched episodes on watching TV shows
- Adds `/history` watch history page with scope tabs
- Links watch history from mobile nav and user menu

## Notes
- Rebased onto current `main` (includes ⌘K, direct streaming, continue watching dismiss, etc.)
- Preserves existing continue-watching mark-complete controls on home

## Test plan
- [ ] Sign in and verify Up Next row shows for in-progress TV shows
- [ ] Verify Because you watched row appears after playback history exists
- [ ] Open `/history` and filter by All / Movies / TV / Anime
- [ ] Confirm ⌘K and continue watching still work on home